### PR TITLE
Correct terminology from AST to CST in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We invite you to push the project forward by implementing a missing part of a la
 
 While tree-sitter gives you a parser for most languages, we still need to write implementations for each supported language.
 
-In practice this means reading the input files, walking the AST provided by tree-sitter, resolving types as best as we can, and finally emitting our standard `Entity` JSON structures.
+In practice this means reading the input files, walking the CST provided by tree-sitter, resolving types as best as we can, and finally emitting our standard `Entity` JSON structures.
 
 Currently we have started implementing 2 languages: Typescript and Python. Typescript is the most advanced language, while Python is still in a POC-stage.
 
@@ -132,7 +132,7 @@ Here are some questions you may have, and hopefully a useful answer to match:
 
 ### It's not possible to do this without using the language runtime/compiler you are targeting, right?
 
-This is probably correct in the literal case. Depending on the language, there may well be things Dossier will not be able to infer since it all it has is the tree-sitter AST and no access to the language runtime. A good example of this would be type inference, or resolving types that are computed from dynamic expressions.
+This is probably correct in the literal case. Depending on the language, there may well be things Dossier will not be able to infer since it all it has is the tree-sitter CST and no access to the language runtime. A good example of this would be type inference, or resolving types that are computed from dynamic expressions.
 
 But you do not need to support 100% of a language to be a useful tool for e.g. creating documentation for a public API of a library. Our task is made simpler by the fact that Dossier only cares about declarations and signatures, which is a much smaller subset of a full language. 
 


### PR DESCRIPTION

When **Dossier** says *“AST provided by Tree-sitter”*, that’s slightly imprecise — what it really means is:

> Dossier uses **Tree-sitter’s parse tree** (a **CST**) as input and **treats it like an AST** for its analysis layer.

Tree-sitter itself always produces a **Concrete Syntax Tree** — a complete structural representation of the text according to the grammar.
Dossier then walks that tree and **builds its own semantic model** (the JSON “Entity” schema).

So the phrase “AST provided by Tree-sitter” is shorthand for:

* *“We use the syntax tree Tree-sitter gives us, and we call it our AST because we don’t do a separate abstraction pass.”*

That’s common in many tools that:

* don’t need to normalize or simplify syntax (e.g., doc extractors, highlighters),
* or treat Tree-sitter’s CST as “good enough” for semantic traversal.

### In summary

| Term            | What Tree-sitter actually provides                        | How Dossier uses it                     |
| --------------- | --------------------------------------------------------- | --------------------------------------- |
| **CST**         | Full parse tree including punctuation and syntax variants | ✅ Consumed directly                     |
| **AST**         | Usually a simplified, semantic model                      | 🚫 Not separate; Dossier reuses the CST |
| **Entity JSON** | Dossier’s normalized output schema                        | ✅ Built from CST traversal              |

So when you see “AST provided by Tree-sitter,” read it as *“Tree-sitter CST used as the working AST.”*